### PR TITLE
GHAの動作時のみretry、timeoutの調整、firefoxの無効化を行いました

### DIFF
--- a/.github/workflows/run_cypress.yml
+++ b/.github/workflows/run_cypress.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        browser: [chrome, firefox, edge]
+        browser: [chrome, edge]
     steps:
       - run: mkdir -p ~/.wheel
       - run: >

--- a/.github/workflows/run_cypress.yml
+++ b/.github/workflows/run_cypress.yml
@@ -65,6 +65,7 @@ jobs:
           start: npm start
           wait-on: "http://localhost:8089"
           wait-on-timeout: 300
+          config: requestTimeout=300000,defaultCommandTimeout=300000,retries=2
 
       - name: upload screenshot
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
GHA長時間動作時、サーバーの応答時間が長くなることがある。
これによりテストが不安定なることを防ぐため、retry、timeoutを調整した。

firefoxがCDPという機能を削除した。
これによりGHAでfirefoxが動作しなくなっている。
一時的にGHAでのfirefoxのテストを無効化した。
https://github.com/cypress-io/cypress/issues/31189