### PR TITLE
fix: guard build_and_deploy against non-master PRs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,7 +7,7 @@ on:
       - closed
 jobs:
   build_and_deploy:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
     env:
       DOCKER_USER_NAME: ${{ vars.DOCKER_USER_NAME }}
       DOCKER_CONTAINER_NAME: ${{ vars.DOCKER_CONTAINER_NAME }}


### PR DESCRIPTION
The branches: [master] filter on pull_request_target is evaluated against github.ref (always the default branch), not the PR's base branch, so it fires for every merged PR. Add an explicit base.ref check to the job condition so build and deploy only runs when a PR is actually merged into master.