### PR TITLE
ci: re-enable automatic release on PR merge into master

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,8 +1,12 @@
 name: build and deploy container
 on:
   workflow_dispatch:
+  pull_request_target:
+    types:
+      - closed
 jobs:
   build_and_deploy:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     env:
       DOCKER_USER_NAME: ${{ vars.DOCKER_USER_NAME }}
       DOCKER_CONTAINER_NAME: ${{ vars.DOCKER_CONTAINER_NAME }}


### PR DESCRIPTION
## Summary
Restores automatic release building, scoped precisely to merged PRs into `master`.

`pull_request_target` resolves which workflow to run using the workflow file version
on the PR's **base branch** - so adding this trigger only to `master`'s copy of
`build_and_deploy.yml` inherently scopes it to PRs whose base is `master`.
`maintenance2023`/`maintenance2026` keep their `workflow_dispatch:`-only copies,
untouched - PRs merged into those branches won't trigger anything.

`pull_request_target` (not `pull_request`) matches the original pre-existing pattern -
it runs with base-repo secrets/context, needed for `DOCKER_PASSWORD`.
`types: [closed]` fires on both merged and just-closed PRs, so the job is guarded with
`if: ... github.event.pull_request.merged == true`. `workflow_dispatch` stays alongside
for ad-hoc manual rebuilds.

**Why this is safe to re-enable now**: earlier this session this trigger was removed
because every firing created a *new*, run-id-tagged release (29 junk releases
accumulated). That root cause is already fixed independently: `tag_name` is
branch-based (one persistent release per branch, updated in place) and `name` is the
computed version number. So from here on, each merged PR into master just updates the
existing `master` release in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)