### PR TITLE
ci: release tag is the version number, so releases never overwrite

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -44,7 +44,7 @@ jobs:
             wheel.sif
             wheel_docker.tar.gz
             source.tar.gz
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.VERSION_NUMBER }}
           name: ${{ env.VERSION_NUMBER }}
           body: "release for ${{ github.ref_name }} @ ${{ github.sha }} (${{ env.VERSION_NUMBER }})"
         env:


### PR DESCRIPTION
## Summary
\`tag_name\` was branch-based, so every build (manual \`workflow_dispatch\`, or the
automatic PR-merge trigger added in #121) overwrote the same release in place - which
is exactly how old master's release got silently overwritten when dev2025 was merged
into master (PR #119), and \`maintenance2026\` (its archive branch) never got a release
built for it at all.

Switches \`tag_name\` to the already-computed \`VERSION_NUMBER\` (same value as \`name\`),
so every future build - manual or automatic - creates a new, permanent,
uniquely-tagged release instead of overwriting one. Same fix already applied directly
to \`maintenance2023\`/\`maintenance2026\` (unprotected branches).

Docker Hub image tagging stays branch-based - separate concern, not a GitHub release
package.

Follow-up: once this lands, dispatching a build for \`maintenance2026\` will resurrect
old master's release content as its own permanent entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)