### PR TITLE
Harden WHEEL_* env-var priority in db.js config loading

### DIFF
--- a/server/app/core/versionInfo.js
+++ b/server/app/core/versionInfo.js
@@ -20,7 +20,7 @@ function aboutWheel(projectRootDir) {
   logger.info("environment variables");
   logger.info(`WHEEL_TEMPD = ${process.env.WHEEL_TEMPD}`);
   logger.info(`WHEEL_CONFIG_DIR = ${process.env.WHEEL_CONFIG_DIR}`);
-  logger.info(`WHEEL_BASE_URL= ${process.env.WHEEL_USE_HTTP}`);
+  logger.info(`WHEEL_BASE_URL = ${process.env.WHEEL_BASE_URL}`);
   logger.info(`WHEEL_USE_HTTP = ${process.env.WHEEL_USE_HTTP}`);
   logger.info(`WHEEL_PORT = ${process.env.WHEEL_PORT}`);
   logger.info(`WHEEL_ACCEPT_ADDRESS = ${process.env.WHEEL_ACCEPT_ADDRESS}`);

--- a/server/app/db/db.js
+++ b/server/app/db/db.js
@@ -103,6 +103,26 @@ function getStringVar(target, alt) {
 }
 
 /**
+ * return the integer parsed from a WHEEL_* environment variable when it is set to a
+ * non-blank string that parses to a number (0 included); otherwise return the fallback
+ * taken from the merged config file / package default.
+ * A blank or whitespace-only env var never overrides the config value, so the documented
+ * priority "non-empty WHEEL_* env var > WHEEL_CONFIG_DIR/server.json > ~/.wheel/server.json
+ * > packaged default" holds. Unlike `parseInt(env, 10) || fallback`, a valid `0` from the
+ * env var is honoured instead of silently falling through to the config value.
+ * @param {string|undefined} envValue - raw process.env.WHEEL_XXX value
+ * @param {number} fallback - value from the merged config file / package default
+ * @returns {number} -
+ */
+function envIntOr(envValue, fallback) {
+  if (typeof envValue !== "string" || envValue.trim() === "") {
+    return fallback;
+  }
+  const parsed = parseInt(envValue, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+/**
  * read default and userdefined config file and merge them
  * @param {string} filename - config file's name
  * @returns {object} -
@@ -161,13 +181,15 @@ module.exports.rsyncExcludeOptionOfWheelSystemFiles = [
 ];
 
 //re-export server settings
-module.exports.port = parseInt(process.env.WHEEL_PORT, 10) || config.port; //default var will be calcurated in app/index.js
+//non-empty WHEEL_PORT wins over every config file (see envIntOr); app/index.js still
+//falls back to a default port when the resolved value is <= 0.
+module.exports.port = envIntOr(process.env.WHEEL_PORT, config.port);
 module.exports.rootDir = getStringVar(config.rootDir, getStringVar(os.homedir(), "/"));
 module.exports.defaultCleanupRemoteRoot = getVar(config.defaultCleanupRemoteRoot, true);
 module.exports.numLogFiles = getIntVar(config.numLogFiles, 5);
 module.exports.maxLogSize = getIntVar(config.maxLogSize, 8388608);
 module.exports.compressLogFile = getVar(config.compressLogFile, true);
-module.exports.numJobOnLocal = parseInt(process.env.WHEEL_NUM_LOCAL_JOB, 10) || getIntVar(config.numJobOnLocal, 1);
+module.exports.numJobOnLocal = envIntOr(process.env.WHEEL_NUM_LOCAL_JOB, getIntVar(config.numJobOnLocal, 1));
 module.exports.defaultTaskRetryCount = getIntVar(config.defaultTaskRetryCount, 1);
 module.exports.gitLFSSize = getIntVar(config.gitLFSSize, 200);
 
@@ -176,3 +198,6 @@ module.exports.jobScheduler = jobScheduler;
 module.exports.remoteHost = new JsonArrayManager(remotehostFilename);
 module.exports.jobScriptTemplate = new JsonArrayManager(jobScriptTemplateFilename);
 module.exports.projectList = new JsonArrayManager(projectListFilename);
+
+/**@internal exported for unit testing only */
+module.exports._internal = { envIntOr };

--- a/server/app/db/version.json
+++ b/server/app/db/version.json
@@ -1,1 +1,1 @@
-{"version": "2026-0817-200401-maintenance" }
+{"version": "2026-0827-204443-beta" }

--- a/server/test/app/db/db.js
+++ b/server/test/app/db/db.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Center for Computational Science, RIKEN All rights reserved.
+ * Copyright (c) Research Institute for Information Technology(RIIT), Kyushu University. All rights reserved.
+ * See License in the project root for the license information.
+ */
+"use strict";
+
+//setup test framework
+const chai = require("chai");
+const expect = chai.expect;
+
+//testee
+const { _internal } = require("../../../app/db/db.js");
+const { envIntOr } = _internal;
+
+describe("UT for db.js config helpers", function () {
+  describe("#envIntOr", ()=>{
+    it("returns the fallback when the env var is undefined", ()=>{
+      expect(envIntOr(undefined, 8089)).to.equal(8089);
+    });
+    it("returns the fallback for an empty-string env var", ()=>{
+      expect(envIntOr("", 8089)).to.equal(8089);
+    });
+    it("returns the fallback for a whitespace-only env var", ()=>{
+      expect(envIntOr("   ", 8089)).to.equal(8089);
+    });
+    it("returns the fallback for a non-numeric env var", ()=>{
+      expect(envIntOr("not-a-number", 8089)).to.equal(8089);
+    });
+    it("returns the parsed integer for a numeric env var (env wins over config)", ()=>{
+      expect(envIntOr("39999", 8089)).to.equal(39999);
+    });
+    it("honours a non-empty '0' instead of falling through to the fallback", ()=>{
+      expect(envIntOr("0", 8089)).to.equal(0);
+    });
+    it("parses a leading integer like parseInt does", ()=>{
+      expect(envIntOr("8080abc", 8089)).to.equal(8080);
+    });
+    it("tolerates surrounding whitespace around a number", ()=>{
+      expect(envIntOr("  4000  ", 8089)).to.equal(4000);
+    });
+  });
+});


### PR DESCRIPTION
## Context

Companion to the `master` PR ("Restore WHEEL_* env-var priority over config files in
loadWheelConfig"). Same motivation: WHEEL on Fugaku **Open OnDemand** runs in a Singularity
container whose launch script exports a fresh `WHEEL_PORT` every session; a stale
`~/.wheel/server.json` must not win.

**This branch does *not* carry the `master` regression.** It still uses the CJS
`readAndMergeConfigFile()` loader (no `c12`), and `port` / `numJobOnLocal` are already
env-first. So a `wheel.sif` built from this branch would **not** exhibit the OOD timeout.

This PR is hardening only:

## Changes

### `server/app/db/db.js` — blank-safe `envIntOr()` helper

`port` and `numJobOnLocal` were resolved with

```js
parseInt(process.env.WHEEL_PORT, 10) || config.port
```

The `|| ` makes any env value that parses to **`0`** falsy, so it silently falls back to the
config file. New helper (CJS, no new deps):

```js
function envIntOr(envValue, fallback) {
  if (typeof envValue !== "string" || envValue.trim() === "") {
    return fallback;                                  // unset / "" / "   " -> config wins
  }
  const parsed = parseInt(envValue, 10);
  return Number.isNaN(parsed) ? fallback : parsed;    // "abc" -> fallback; "0" -> 0
}
```

`port` and `numJobOnLocal` now go through it. **Behavior delta is only the `0` case**; unset /
blank / whitespace / non-numeric / normal values behave exactly as before. Exports
`module.exports._internal = { envIntOr }` for the unit test.

### `server/app/core/versionInfo.js` — log-label bug

```diff
-  logger.info(`WHEEL_BASE_URL= ${process.env.WHEEL_USE_HTTP}`);
+  logger.info(`WHEEL_BASE_URL = ${process.env.WHEEL_BASE_URL}`);
```

The startup banner printed `WHEEL_USE_HTTP`'s value under a `WHEEL_BASE_URL=` label.

### `server/test/app/db/db.js` — new file

8 `envIntOr` cases (undefined / `""` / `"   "` / `"not-a-number"` → fallback; `"39999"` →
39999; `"0"` → 0; `"8080abc"` → 8080; `"  4000  "` → 4000).

## Testing

`envIntOr` suite: 8/8 pass. `db.js`-dependent core tests (`Logging`, `environmentVariable`,
`exportProject`) still pass. Smoke: stale `~/.wheel/server.json` `port: 12345` +
`WHEEL_PORT=39997` → `db.js` `port = 39997`; `WHEEL_NUM_LOCAL_JOB=0` → `numJobOnLocal = 0`
(was `1` before).

Not run locally: the full remote suite (needs the `openpbs` testbed container from
`run_test.yml`); CI will cover it on push.

## Not touched

`baseURL` / `useHttp` / `acceptAddress` / `enableAuth` / `enableWebApi` / `logLevel` on this
branch are pure `process.env` reads with no config-file path at all, so they are already
env-only and need no change.
